### PR TITLE
Add component tests v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ As an example, there is a reusable smoke test [cypress/integration/smoke.js](cyp
 npx cypress run --config-file cypress-smoke.json
 ```
 
+## Component tests
+
+Unit (individual JS functions) and component tests (React components) can be run without any server.
+
+```shell
+$ npx cypress open --config-file cypress-unit.json
+```
+
+These tests leave alongside Jest tests in [src](src) folder and are named `*.cy-spec.js`. Implemented using [cypress-react-unit-test](https://github.com/bahmutov/cypress-react-unit-test).
+
 ## License
 
 This project is licensed under the terms of the [MIT license](/LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npx cypress run --config-file cypress-smoke.json
 
 ## Component tests
 
-Unit (individual JS functions) and component tests (React components) can be run without any server. There is no need to set anything up, this project work right out of the box without any additional steps, except you need to add `import 'cypress-react-unit-test'` to Cypress support file.
+Unit (individual JS functions) and component tests (React components) can be run without any server. There is no need to set anything up, this project works right out of the box without any additional steps, except you need to add `import 'cypress-react-unit-test'` to your Cypress [`supportFile`](https://on.cypress.io/configuration#Folders-Files).
 
 ```shell
 $ npx cypress open --config-file cypress-unit.json

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npx cypress run --config-file cypress-smoke.json
 
 ## Component tests
 
-Unit (individual JS functions) and component tests (React components) can be run without any server.
+Unit (individual JS functions) and component tests (React components) can be run without any server. There is no need to set anything up, this project work right out of the box without any additional steps, except you need to add `import 'cypress-react-unit-test'` to Cypress support file.
 
 ```shell
 $ npx cypress open --config-file cypress-unit.json

--- a/circle.yml
+++ b/circle.yml
@@ -5,8 +5,14 @@ orbs:
 workflows:
   build:
     jobs:
+      - cypress/install:
+          name: Install 📦
+
       - cypress/run:
-          name: full tests
+          name: full tests 🧪
+          requires:
+            - Install 📦
+          install-command: echo 'Nothing to install in this job'
           # we need to start the web application
           start: npm start
           command: NODE_ENV=test npm run cypress:run
@@ -25,9 +31,20 @@ workflows:
             # https://coveralls.io/github/cypress-io/cypress-example-todomvc-redux
             - run: npm run coveralls
 
+      - cypress/run:
+          name: component tests 🧱
+          requires:
+            - Install 📦
+          install-command: echo 'Nothing to install in this job'
+          command: npx cypress run --config-file cypress-unit.json
+          no-workspace: true
+
 
       - cypress/run:
-          name: smoke tests
+          name: smoke tests 💨
+          requires:
+            - Install 📦
+          install-command: echo 'Nothing to install in this job'
           # we will only run smoke tests on master branch
           filters:
             branches:
@@ -35,6 +52,4 @@ workflows:
                 - master
           start: npm start
           command: NODE_ENV=test npx cypress run --config-file cypress-smoke.json
-          # there are no jobs to follow this one
-          # so no need to save the workspace files (saves time)
           no-workspace: true

--- a/cypress-unit.json
+++ b/cypress-unit.json
@@ -1,0 +1,8 @@
+{
+  "$schema":"https://on.cypress.io/cypress.schema.json",
+  "pluginsFile": false,
+  "fixturesFolder": false,
+  "supportFile": "cypress/support/unit.js",
+  "integrationFolder": "src",
+  "testFiles": "**/*.cy-spec.js"
+}

--- a/cypress-unit.json
+++ b/cypress-unit.json
@@ -4,5 +4,7 @@
   "fixturesFolder": false,
   "supportFile": "cypress/support/unit.js",
   "integrationFolder": "src",
-  "testFiles": "**/*.cy-spec.js"
+  "testFiles": "**/*.cy-spec.js",
+  "viewportWidth": 300,
+  "viewportHeight": 300
 }

--- a/cypress/support/unit.js
+++ b/cypress/support/unit.js
@@ -1,0 +1,2 @@
+// https://github.com/bahmutov/cypress-react-unit-test
+import 'cypress-react-unit-test'

--- a/package-lock.json
+++ b/package-lock.json
@@ -5375,6 +5375,12 @@
         }
       }
     },
+    "cypress-react-unit-test": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/cypress-react-unit-test/-/cypress-react-unit-test-2.5.1.tgz",
+      "integrity": "sha512-4AZJ/nRJIKjzC69Uem/nmRkGTy8Oz8geRYJcc+AnHlc43sW4t6c8tUePykbjpbyn12p1xHy+TD5/EVpMkHtZeQ==",
+      "dev": true
+    },
     "dash-ast": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5375,9 +5375,9 @@
       }
     },
     "cypress-react-unit-test": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/cypress-react-unit-test/-/cypress-react-unit-test-2.5.1.tgz",
-      "integrity": "sha512-4AZJ/nRJIKjzC69Uem/nmRkGTy8Oz8geRYJcc+AnHlc43sW4t6c8tUePykbjpbyn12p1xHy+TD5/EVpMkHtZeQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cypress-react-unit-test/-/cypress-react-unit-test-2.7.0.tgz",
+      "integrity": "sha512-F3GOL6v163meokw6fv+bRFc2dsJQ72xZ0tJHj4ei5loyM8nbbH1rh5TqIlXOa4JPTKsAJeA851hq2C43vgdYQg==",
       "dev": true
     },
     "dash-ast": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2583,7 +2583,6 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
       "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.12.0"
       }
@@ -7519,7 +7518,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -10525,35 +10523,16 @@
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
     "react-redux": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.0.tgz",
-      "integrity": "sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-6.0.1.tgz",
+      "integrity": "sha512-T52I52Kxhbqy/6TEfBv85rQSDz6+Y28V/pf52vDWs1YRXG19mcFOGfHnY2HsNFHyhP+ST34Aih98fvt6tqwVcQ==",
       "requires": {
-        "@babel/runtime": "^7.5.5",
+        "@babel/runtime": "^7.3.1",
         "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.7.2",
-        "react-is": "^16.9.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "react-is": {
-          "version": "16.13.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
-          "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
-        },
-        "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
-        }
+        "react-is": "^16.8.2"
       }
     },
     "read-only-stream": {
@@ -10639,8 +10618,7 @@
     "regenerator-runtime": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
-      "dev": true
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regenerator-transform": {
       "version": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prop-types": "15.7.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "react-redux": "7.2.0",
+    "react-redux": "6.0.1",
     "redux": "4.0.5",
     "reselect": "4.0.0",
     "todomvc-app-css": "2.3.0"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "coveralls": "3.0.11",
     "cross-env": "6.0.3",
     "cypress": "4.3.0",
+    "cypress-react-unit-test": "2.5.1",
     "istanbul-lib-coverage": "3.0.0",
     "parcel-bundler": "1.12.4",
     "start-server-and-test": "1.10.11"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "dev": "cross-env NODE_ENV=test start-test 1234 cypress:open",
     "report:coverage": "nyc report --reporter=html",
     "report:coverage:text": "nyc report --reporter=text",
-    "coveralls": "cat coverage/lcov.info | coveralls"
+    "coveralls": "cat coverage/lcov.info | coveralls",
+    "component": "npx cypress open --config-file cypress-unit.json"
   },
   "repository": {
     "type": "git",
@@ -42,7 +43,7 @@
     "coveralls": "3.0.11",
     "cross-env": "6.0.3",
     "cypress": "4.3.0",
-    "cypress-react-unit-test": "2.5.1",
+    "cypress-react-unit-test": "2.7.0",
     "istanbul-lib-coverage": "3.0.0",
     "parcel-bundler": "1.12.4",
     "start-server-and-test": "1.10.11"

--- a/src/actions/index.cy-spec.js
+++ b/src/actions/index.cy-spec.js
@@ -1,0 +1,45 @@
+import * as types from '../constants/ActionTypes'
+import * as actions from './index'
+
+describe('todo actions', () => {
+  it('addTodo should create ADD_TODO action', () => {
+    expect(actions.addTodo('Use Redux')).to.deep.equal({
+      type: types.ADD_TODO,
+      text: 'Use Redux'
+    })
+  })
+
+  it('deleteTodo should create DELETE_TODO action', () => {
+    expect(actions.deleteTodo(1)).to.deep.equal({
+      type: types.DELETE_TODO,
+      id: 1
+    })
+  })
+
+  it('editTodo should create EDIT_TODO action', () => {
+    expect(actions.editTodo(1, 'Use Redux everywhere')).to.deep.equal({
+      type: types.EDIT_TODO,
+      id: 1,
+      text: 'Use Redux everywhere'
+    })
+  })
+
+  it('completeTodo should create COMPLETE_TODO action', () => {
+    expect(actions.completeTodo(1)).to.deep.equal({
+      type: types.COMPLETE_TODO,
+      id: 1
+    })
+  })
+
+  it('completeAll should create COMPLETE_ALL action', () => {
+    expect(actions.completeAllTodos()).to.deep.equal({
+      type: types.COMPLETE_ALL_TODOS
+    })
+  })
+
+  it('clearCompleted should create CLEAR_COMPLETED action', () => {
+    expect(actions.clearCompleted()).to.deep.equal({
+      type: types.CLEAR_COMPLETED
+    })
+  })
+})

--- a/src/components/App.cy-spec.js
+++ b/src/components/App.cy-spec.js
@@ -1,0 +1,23 @@
+// compare to App.spec.js
+import React from 'react'
+import App from './App'
+
+// we are making mini application - thus we need a store!
+import { Provider } from 'react-redux'
+import { createStore } from 'redux'
+import reducer from '../reducers'
+const store = createStore(reducer)
+
+describe('components', () => {
+  it('should render', () => {
+    cy.mount(
+      <Provider store={store}>
+        <App></App>
+      </Provider>
+    )
+    cy.get('header').should('be.visible')
+    // you can see that without any todos, the main section is empty
+    // and thus invisible
+    cy.get('.main').should('exist')
+  })
+})

--- a/src/components/App.cy-spec.js
+++ b/src/components/App.cy-spec.js
@@ -6,18 +6,43 @@ import App from './App'
 import { Provider } from 'react-redux'
 import { createStore } from 'redux'
 import reducer from '../reducers'
+import {addTodo, completeTodo} from '../actions'
 const store = createStore(reducer)
 
 describe('components', () => {
-  it('should render', () => {
+  const setup = () => {
+    cy.viewport(600, 700)
+    // our CSS styles assume the app is inside
+    // a DIV element with class "todoapp"
     cy.mount(
       <Provider store={store}>
-        <App></App>
-      </Provider>
+        <div className="todoapp">
+          <App></App>
+        </div>
+      </Provider>,
+      null,
+      { cssFile: 'node_modules/todomvc-app-css/index.css' }
     )
+  }
+
+  it('should render', () => {
+    setup()
     cy.get('header').should('be.visible')
     // you can see that without any todos, the main section is empty
     // and thus invisible
     cy.get('.main').should('exist')
+  })
+
+  it('should render a couple todos', () => {
+    // use application code to interact with store
+    store.dispatch(addTodo('write app code'))
+    store.dispatch(addTodo('test components using Cypress'))
+    store.dispatch(completeTodo(1))
+    setup()
+
+    // make sure the list of items is correctly checked
+    cy.get('.todo').should('have.length', 2)
+    cy.contains('.todo', 'write app code').should('not.have.class', 'completed')
+    cy.contains('.todo', 'test components using Cypress').should('have.class', 'completed')
   })
 })

--- a/src/components/Footer.cy-spec.js
+++ b/src/components/Footer.cy-spec.js
@@ -1,0 +1,64 @@
+// compare to tests in "Footer.spec.js"
+import React from 'react'
+import Footer from './Footer'
+
+// we are making mini application - thus we need a store!
+import { Provider } from 'react-redux'
+import { createStore } from 'redux'
+import reducer from '../reducers'
+
+const store = createStore(reducer)
+
+const setup = propOverrides => {
+  const props = Object.assign({
+    completedCount: 0,
+    activeCount: 0,
+    onClearCompleted: cy.stub().as('clear'),
+  }, propOverrides)
+
+  cy.mount(
+    <Provider store={store}>
+      <Footer {...props} />
+    </Provider>
+  )
+}
+
+describe('components', () => {
+  describe('Footer', () => {
+    it('should render container', () => {
+      setup()
+      cy.contains('footer', 'No items left').should('have.class', 'footer')
+    })
+
+    it('should display active count when above 0', () => {
+      setup({ activeCount: 1 })
+      cy.contains('1 item left')
+    })
+
+    it('should render filters', () => {
+      setup()
+      cy.get('footer li').should('have.length', 3)
+        .should((li) => {
+          expect(li[0]).to.have.text('All')
+          expect(li[1]).to.have.text('Active')
+          expect(li[2]).to.have.text('Completed')
+        })
+    })
+
+    it('shouldnt show clear button when no completed todos', () => {
+      setup({ completedCount: 0 })
+      cy.contains('button', 'Clear completed').should('not.exist')
+    })
+
+    it('should render clear button when completed todos', () => {
+      setup({ completedCount: 1 })
+      cy.contains('button', 'Clear completed').should('have.class', 'clear-completed')
+    })
+
+    it('should call onClearCompleted on clear button click', () => {
+      setup({ completedCount: 1 })
+      cy.contains('button', 'Clear completed').click()
+      cy.get('@clear').should('have.been.called')
+    })
+  })
+})

--- a/src/components/Footer.cy-spec.js
+++ b/src/components/Footer.cy-spec.js
@@ -6,7 +6,6 @@ import Footer from './Footer'
 import { Provider } from 'react-redux'
 import { createStore } from 'redux'
 import reducer from '../reducers'
-
 const store = createStore(reducer)
 
 const setup = propOverrides => {

--- a/src/components/Header.cy-spec.js
+++ b/src/components/Header.cy-spec.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import Header from './Header'
+
+// we are making mini application - thus we need a store!
+import { Provider } from 'react-redux'
+import { createStore } from 'redux'
+import reducer from '../reducers'
+const store = createStore(reducer)
+
+describe('components', () => {
+  describe('Header', () => {
+    beforeEach(() => {
+      const props = {
+        addTodo: cy.stub().as('addTodo')
+      }
+      cy.mount(
+        <Provider store={store}>
+          <Header {...props} />
+        </Provider>
+      )
+    })
+
+    it('should render correctly', () => {
+      cy.get('header').should('have.class', 'header')
+        .contains('h1', 'todos')
+      cy.get('header input').should('have.attr', 'placeholder', 'What needs to be done?')
+    })
+
+    it('should call addTodo if length of text is greater than 0', () => {
+      cy.get('header input').type('{enter}')
+      cy.get('@addTodo').should('not.have.been.called')
+
+      cy.get('header input').type('Use Redux{enter}')
+      cy.get('@addTodo').should('have.been.called')
+    })
+  })
+})

--- a/src/components/MainSection.cy-spec.js
+++ b/src/components/MainSection.cy-spec.js
@@ -1,0 +1,90 @@
+import React from 'react'
+import MainSection from './MainSection'
+
+// we are making mini application - thus we need a store!
+import { Provider } from 'react-redux'
+import { createStore } from 'redux'
+import reducer from '../reducers'
+const store = createStore(reducer)
+
+const setup = propOverrides => {
+  const props = Object.assign({
+    todosCount: 2,
+    completedCount: 1,
+    actions: {
+      editTodo: cy.stub().as('edit'),
+      deleteTodo: cy.stub().as('delete'),
+      completeTodo: cy.stub().as('complete'),
+      completeAllTodos: cy.stub().as('completeAll'),
+      clearCompleted: cy.stub().as('clearCompleted')
+    }
+  }, propOverrides)
+
+  cy.mount(
+    <Provider store={store}>
+      <MainSection {...props} />
+    </Provider>
+  )
+}
+
+describe('components', () => {
+  describe('MainSection', () => {
+    it('should render container', () => {
+      setup()
+      cy.get('section').should('have.class', 'main')
+    })
+
+    describe('toggle all input', () => {
+      it('should render', () => {
+        setup()
+        cy.get('input[type=checkbox]')
+          .should('have.class', 'toggle-all')
+          .and('not.be.checked')
+      })
+
+      it('should be checked if all todos completed', () => {
+        setup({
+          completedCount: 2
+        })
+        cy.get('input[type=checkbox]')
+          .should('be.checked')
+      })
+
+      it('should call completeAllTodos on change', () => {
+        setup()
+        cy.get('input[type=checkbox]').click()
+        cy.get('@completeAll').should('be.called')
+      })
+    })
+
+    describe('footer', () => {
+      it('should render', () => {
+        setup()
+        cy.get('footer').contains('1 item left')
+      })
+
+      it('onClearCompleted should call clearCompleted', () => {
+        setup()
+        cy.contains('button', 'Clear completed').click()
+        cy.get('@clearCompleted').should('have.been.called')
+      })
+    })
+
+    describe('visible todo list', () => {
+      it('should render', () => {
+        setup()
+        cy.get('li').should('have.length', 3)
+      })
+    })
+
+    describe('toggle all input and footer', () => {
+      it('should not render if there are no todos', () => {
+        setup({
+          todosCount: 0,
+          completedCount: 0
+        })
+        cy.get('li').should('have.length', 0)
+      })
+    })
+  })
+})

--- a/src/components/MainSection.cy-spec.js
+++ b/src/components/MainSection.cy-spec.js
@@ -23,7 +23,9 @@ const setup = propOverrides => {
   cy.mount(
     <Provider store={store}>
       <MainSection {...props} />
-    </Provider>
+    </Provider>,
+    null,
+    { cssFile: 'node_modules/todomvc-app-css/index.css' }
   )
 }
 
@@ -52,7 +54,7 @@ describe('components', () => {
 
       it('should call completeAllTodos on change', () => {
         setup()
-        cy.get('input[type=checkbox]').click()
+        cy.get('input[type=checkbox]').click({ force: true })
         cy.get('@completeAll').should('be.called')
       })
     })

--- a/src/components/TodoItem.cy-spec.js
+++ b/src/components/TodoItem.cy-spec.js
@@ -1,0 +1,94 @@
+import React from 'react'
+import TodoItem from './TodoItem'
+
+// we are making mini application - thus we need a store!
+import { Provider } from 'react-redux'
+import { createStore } from 'redux'
+import reducer from '../reducers'
+const store = createStore(reducer)
+
+const setup = ( editing = false ) => {
+  const props = {
+    todo: {
+      id: 0,
+      text: 'Use Redux',
+      completed: false
+    },
+    editTodo: cy.stub().as('edit'),
+    deleteTodo: cy.stub().as('delete'),
+    completeTodo: cy.stub().as('completeTodo')
+  }
+
+  cy.mount(
+    <Provider store={store}>
+      <TodoItem {...props} />
+    </Provider>
+  )
+
+  if (editing) {
+    cy.get('label').dblclick()
+  }
+}
+
+describe('components', () => {
+  describe('TodoItem', () => {
+    it('initial render', () => {
+      setup()
+
+      cy.get('li').should('have.class', 'todo')
+        .find('div').should('have.class', 'view')
+
+      cy.get('input[type=checkbox]')
+        .should('have.class', 'toggle')
+        .and('not.be.checked')
+
+      cy.contains('label', 'Use Redux')
+      cy.get('button').should('have.class', 'destroy')
+    })
+
+    it('input onChange should call completeTodo', () => {
+      setup()
+      cy.get('input').check()
+      cy.get('@completeTodo').should('have.been.calledWith', 0)
+    })
+
+    it('button onClick should call deleteTodo', () => {
+      setup()
+      cy.get('.destroy').click()
+      cy.get('@delete').should('have.been.calledWith', 0)
+    })
+
+    it('label onDoubleClick should put component in edit state', () => {
+      setup()
+      cy.get('label').dblclick()
+      cy.get('li').should('have.class', 'editing')
+    })
+
+    it('edit state render', () => {
+      setup(true)
+      cy.get('li').should('have.class', 'editing')
+      cy.get('input')
+        .should('be.visible')
+        .and('have.value', 'Use Redux')
+    })
+
+    it('TodoTextInput onSave should call editTodo', () => {
+      setup(true)
+      cy.focused().type('{enter}')
+      cy.get('@edit').should('have.been.calledWith', 0, 'Use Redux')
+    })
+
+    it('TodoTextInput onSave should call deleteTodo if text is empty', () => {
+      setup(true)
+      cy.focused().clear().type('{enter}')
+      cy.get('@delete').should('have.been.calledWith', 0)
+    })
+
+    it('TodoTextInput onSave should exit component from edit state', () => {
+      setup(true)
+      cy.get('li').should('have.class', 'editing')
+      cy.focused().type('{enter}')
+      cy.get('li').should('not.have.class', 'editing')
+    })
+  })
+})

--- a/src/components/TodoItem.cy-spec.js
+++ b/src/components/TodoItem.cy-spec.js
@@ -19,10 +19,17 @@ const setup = ( editing = false ) => {
     completeTodo: cy.stub().as('completeTodo')
   }
 
+  // because our CSS styles are global, they assume
+  // each todo item is inside ".todo-list" element
+  // simple: place TodoItem in a <ul class="todo-list>
   cy.mount(
     <Provider store={store}>
-      <TodoItem {...props} />
-    </Provider>
+      <ul class="todo-list">
+        <TodoItem {...props} />
+      </ul>
+    </Provider>,
+    null,
+    { cssFile: 'node_modules/todomvc-app-css/index.css' }
   )
 
   if (editing) {
@@ -54,7 +61,8 @@ describe('components', () => {
 
     it('button onClick should call deleteTodo', () => {
       setup()
-      cy.get('.destroy').click()
+      // button only becomes visible on hover
+      cy.get('.destroy').click({force: true})
       cy.get('@delete').should('have.been.calledWith', 0)
     })
 

--- a/src/components/TodoList.cy-spec.js
+++ b/src/components/TodoList.cy-spec.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import TodoList from './TodoList'
+
+// we are making mini application - thus we need a store!
+import { Provider } from 'react-redux'
+import { createStore } from 'redux'
+import reducer from '../reducers'
+const store = createStore(reducer)
+
+const setup = () => {
+  const props = {
+    filteredTodos: [
+      {
+        text: 'Use Redux',
+        completed: false,
+        id: 0
+      }, {
+        text: 'Run the tests',
+        completed: true,
+        id: 1
+      }
+    ],
+    // we need to create stubs
+    // because the component runs validation on props
+    actions: {
+      editTodo: cy.stub(),
+      deleteTodo: cy.stub(),
+      completeTodo: cy.stub(),
+      completeAll: cy.stub(),
+      clearCompleted: cy.stub()
+    }
+  }
+
+  cy.mount(
+    <Provider store={store}>
+      <TodoList {...props} />
+    </Provider>
+  )
+}
+
+describe('components', () => {
+  describe('TodoList', () => {
+    it('should render container', () => {
+      setup()
+      cy.get('ul').should('have.class', 'todo-list')
+    })
+
+    it('should render todos', () => {
+      setup()
+      cy.get('li').should('have.length', 2)
+        .first().should('have.class', 'todo').and('have.text', 'Use Redux')
+        .find('input[type=checkbox]').should('not.be.checked')
+
+      cy.get('li')
+        .eq(1).should('have.class', 'todo').and('have.text', 'Run the tests')
+        .find('input[type=checkbox]').should('be.checked')
+    })
+  })
+})

--- a/src/components/TodoList.cy-spec.js
+++ b/src/components/TodoList.cy-spec.js
@@ -34,7 +34,9 @@ const setup = () => {
   cy.mount(
     <Provider store={store}>
       <TodoList {...props} />
-    </Provider>
+    </Provider>,
+    null,
+    { cssFile: 'node_modules/todomvc-app-css/index.css' }
   )
 }
 


### PR DESCRIPTION
- closes #99

Run locally with `npx cypress open --config-file cypress-unit.json `

In order for component testing to work I had to downgrade react-redux from v7 to v6 to avoid using React hooks.

Then pick a file - I copied most component tests from `/src` folder so you can compare them

<img width="800" alt="Screen Shot 2020-04-01 at 5 25 00 PM" src="https://user-images.githubusercontent.com/2212006/78188142-b95e1800-743d-11ea-9085-53844f0f6a20.png">

![todo-item](https://user-images.githubusercontent.com/2212006/78188876-02fb3280-743f-11ea-82b0-a8644c9d6f9d.gif)


## Observations

No shallow rendering. Every test for X only imports `X` and `React` (and additional Redux store, which can be a utility function)

Individual components would look better if they had some text or default styles. Right now the components rely on global styles from `index.js` 

```
import 'todomvc-app-css/index.css'
```

Thus I have added `style` and `cssFile` support to `cypress-react-unit-test`, so a typical component test mounts like this

```js
// because our CSS styles are global, they assume
// each todo item is inside ".todo-list" element
// simple: place TodoItem in a <ul class="todo-list>
cy.mount(
  <Provider store={store}>
    <ul class="todo-list">
      <TodoItem {...props} />
    </ul>
  </Provider>,
  null,
  { cssFile: 'node_modules/todomvc-app-css/index.css' }
)
```

which looks good.

Example: TodoList component

<img width="1279" alt="Screen Shot 2020-04-02 at 10 42 18 AM" src="https://user-images.githubusercontent.com/2212006/78264631-69309580-74d1-11ea-98e5-cdb4238f3e64.png">


Example: App component

<img width="1279" alt="Screen Shot 2020-04-02 at 10 56 22 AM" src="https://user-images.githubusercontent.com/2212006/78264561-54ec9880-74d1-11ea-8ed8-97f37bd43e5f.png">

Note: you can plug in visual component testing https://on.cypress.io/visual-testing there