### PR TITLE
Assert the element does not exist instead of not visible to be more explicit

### DIFF
--- a/cypress/integration/full-spec.js
+++ b/cypress/integration/full-spec.js
@@ -391,10 +391,10 @@ context('Editing', function () {
 
     cy.get('@secondTodo')
       .find('.toggle')
-      .should('not.be.visible')
+      .should('not.exist')
     cy.get('@secondTodo')
       .find('label')
-      .should('not.be.visible')
+      .should('not.exist')
   })
 
   it('should save edits on blur', function () {


### PR DESCRIPTION
For upcoming changes in https://github.com/cypress-io/cypress/pull/9239